### PR TITLE
Issue with needless parameter

### DIFF
--- a/kurento-recorder/js/index.js
+++ b/kurento-recorder/js/index.js
@@ -14,7 +14,7 @@
 * limitations under the License.
 *
 */
-
+ 
 function getopts(args, opts)
 {
   var result = opts.default || {};

--- a/kurento-recorder/js/index.js
+++ b/kurento-recorder/js/index.js
@@ -130,7 +130,7 @@ function startRecording() {
             webRtcPeer.processAnswer(answer);
           });
 
-          client.connect(webRtc, webRtc, recorder, function(error) {
+          client.connect(webRtc, recorder, function(error) {
             if (error) return onError(error);
 
             console.log("Connected");


### PR DESCRIPTION
In the calling of the method `client.connect` parameter webRrt is given twice. 
It doesn't raise any error, but prevents connect.
